### PR TITLE
Replace PROJECT_NAME with PROJECT_ID and create FIRESTORE_LOCATION 

### DIFF
--- a/config-env.sh
+++ b/config-env.sh
@@ -60,6 +60,7 @@ gcloud services enable \
     --quiet
 
 export REGION=us-east1
+export FIRESTORE_LOCATION=nam5
 export WORKFLOW_LOCATION=$REGION
 export TRIGGER_LOCATION=$REGION
 

--- a/customer-service/setup.sh
+++ b/customer-service/setup.sh
@@ -33,7 +33,7 @@ gcloud services enable \
     compute.googleapis.com \
     --quiet
 
-gcloud projects add-iam-policy-binding $PROJECT_NAME \
+gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:$PROJECT_NUMBER-compute@developer.gserviceaccount.com" \
   --role="roles/alloydb.client"
 
@@ -59,7 +59,7 @@ gcloud beta alloydb clusters create $CLUSTER \
     --password=$DB_PASSWORD \
     --network=default \
     --region=$REGION \
-    --project=$PROJECT_NAME
+    --project=$PROJECT_ID
 
 gcloud beta alloydb clusters describe $CLUSTER --region=$REGION
 
@@ -68,7 +68,7 @@ gcloud beta alloydb instances create $INSTANCE \
     --region=$REGION \
     --instance-type=PRIMARY \
     --cpu-count=2 \
-    --project=$PROJECT_NAME
+    --project=$PROJECT_ID
 
 gcloud beta alloydb instances describe $INSTANCE --cluster=$CLUSTER --region $REGION
 
@@ -90,10 +90,10 @@ gcloud artifacts repositories create cymbal-eats \
 
 cd ./db
 
-gcloud builds submit -t $REGION-docker.pkg.dev/$PROJECT_NAME/cymbal-eats/db-job:latest
+gcloud builds submit -t $REGION-docker.pkg.dev/$PROJECT_ID/cymbal-eats/db-job:latest
 
 gcloud beta run jobs create db-job \
-    --image=$REGION-docker.pkg.dev/$PROJECT_NAME/cymbal-eats/db-job:latest \
+    --image=$REGION-docker.pkg.dev/$PROJECT_ID/cymbal-eats/db-job:latest \
     --set-env-vars DB_HOST=$DB_HOST \
     --set-env-vars PGUSER=$DB_USER \
     --set-env-vars PGPASSWORD=$DB_PASSWORD \
@@ -111,12 +111,12 @@ gcloud auth configure-docker $REGION-docker.pkg.dev --quiet
 
 docker build -f src/main/docker/Dockerfile.jvm --tag customer-service .
 
-docker tag customer-service $REGION-docker.pkg.dev/$PROJECT_NAME/cymbal-eats/customer-service:latest
+docker tag customer-service $REGION-docker.pkg.dev/$PROJECT_ID/cymbal-eats/customer-service:latest
 
-docker push $REGION-docker.pkg.dev/$PROJECT_NAME/cymbal-eats/customer-service:latest
+docker push $REGION-docker.pkg.dev/$PROJECT_ID/cymbal-eats/customer-service:latest
 
 gcloud run deploy customer-service \
-  --image=$REGION-docker.pkg.dev/$PROJECT_NAME/cymbal-eats/customer-service:latest \
+  --image=$REGION-docker.pkg.dev/$PROJECT_ID/cymbal-eats/customer-service:latest \
   --set-env-vars DB_USER=$DB_USER \
   --set-env-vars DB_PASS=$DB_PASSWORD \
   --set-env-vars DB_DATABASE=$DB_DATABASE \

--- a/menu-service/setup.sh
+++ b/menu-service/setup.sh
@@ -76,12 +76,12 @@ gcloud compute networks vpc-access connectors create ${VPC_CONNECTOR} \
 ./mvnw clean package -DskipTests
 
 docker build -f src/main/docker/Dockerfile.jvm \
-    --tag gcr.io/$PROJECT_NAME/menu-service .
+    --tag gcr.io/$PROJECT_ID/menu-service .
 
-docker push gcr.io/$PROJECT_NAME/menu-service
+docker push gcr.io/$PROJECT_ID/menu-service
 
 gcloud run deploy $MENU_SERVICE_NAME \
-    --image=gcr.io/$PROJECT_NAME/menu-service:latest \
+    --image=gcr.io/$PROJECT_ID/menu-service:latest \
     --region $REGION \
     --allow-unauthenticated \
     --set-env-vars DB_USER=$DB_USER \

--- a/order-service/setup.sh
+++ b/order-service/setup.sh
@@ -26,7 +26,7 @@ gcloud services enable \
     pubsub.googleapis.com \
     --quiet
 
-gcloud firestore databases create --location=$REGION
+gcloud firestore databases create --location=$FIRESTORE_LOCATION
 
 sed "s/PROJECT_ID/$PROJECT_ID/g" firebaserc.tmpl > .firebaserc
 


### PR DESCRIPTION
These changes will fix several gcloud issues that result from PROJECT_NAME being used instead of PROJECT_ID (deployments will fail if these two don't match). Also, because Firestore locations are a subset of Google Cloud locations (https://firebase.google.com/docs/firestore/locations), I introduced a new user parameter, FIRESTORE_LOCATION, defaulting to a US multi-region location.